### PR TITLE
Add PostGIS to image and respin images [release]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           name: "Build Docker Images"
           command: |
             ./build-images.sh
+            docker images
             echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
       - deploy:
           name: "Publish Docker Images (main branch only)"

--- a/10.17/Dockerfile
+++ b/10.17/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/10.17/postgis/Dockerfile
+++ b/10.17/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:10.17
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/11.12/Dockerfile
+++ b/11.12/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/11.12/postgis/Dockerfile
+++ b/11.12/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:11.12
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/12.7/Dockerfile
+++ b/12.7/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/12.7/postgis/Dockerfile
+++ b/12.7/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:12.7
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/13.3/Dockerfile
+++ b/13.3/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/13.3/postgis/Dockerfile
+++ b/13.3/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:13.3
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/9.6/postgis/Dockerfile
+++ b/9.6/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:9.6.22
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gosu \
 		dirmngr \
 	&& \
-	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | sudo tar -xz && \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 docker build --file 9.6/Dockerfile -t cimg/postgres:9.6.22  -t cimg/postgres:9.6 .
+docker build --file 9.6/postgis/Dockerfile -t cimg/postgres:9.6.22-postgis  -t cimg/postgres:9.6-postgis .
 docker build --file 10.17/Dockerfile -t cimg/postgres:10.17 .
+docker build --file 10.17/postgis/Dockerfile -t cimg/postgres:10.17-postgis .
 docker build --file 11.12/Dockerfile -t cimg/postgres:11.12 .
+docker build --file 11.12/postgis/Dockerfile -t cimg/postgres:11.12-postgis .
 docker build --file 12.7/Dockerfile -t cimg/postgres:12.7 .
+docker build --file 12.7/postgis/Dockerfile -t cimg/postgres:12.7-postgis .
 docker build --file 13.3/Dockerfile -t cimg/postgres:13.3 .
+docker build --file 13.3/postgis/Dockerfile -t cimg/postgres:13.3-postgis .

--- a/manifest
+++ b/manifest
@@ -2,4 +2,4 @@
 
 repository=postgres
 parent=base
-variants=()
+variants=(postgis)

--- a/variants/postgis.Dockerfile.template
+++ b/variants/postgis.Dockerfile.template
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/%%PARENT%%:%%PARENT_TAG%%
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install


### PR DESCRIPTION
Closes #6.

This PR adds a "-postgis" variant to this image. I considered just including it in the main image but the addition of PostGIS and its dependencies made the image over 0.5GiB larger. That's a significant amount thus a variant image it is.

This PR also respins the existing PostgreSQL releases we have since the image is still in beta. This creates PostGIS variants for all existing images (of of the date of this PR).

I will add info into the readme in the GA PR.