### PR TITLE
Build additional PostgreSQL modules

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	cd postgresql-${PG_VER} && \
 	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
 	make && \
-	make install all
+	make install all && \
+	cd contrib && \
+	make && \
+	make install
 
 RUN mkdir /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
#11 mentions a few extension that aren't available in the current image.

This PR builds and installs all additional modules when compiling PostgreSQL from source.

Also see: https://www.postgresql.org/docs/14/contrib.html (the instructions on how to build and install the modules are near the end of the page).

With the changes I can successfully build all images locally with `build-images.sh`. For the time being I only confirmed that the hstore extension works on the 13.3 image (`CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public;`).

Please let me know if there is anything I can change or provide you with to get this merged.