### PR TITLE
Compile with libuuid - for PG v13.4 [release]

### DIFF
--- a/13.4/Dockerfile
+++ b/13.4/Dockerfile
@@ -11,6 +11,7 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline-dev \
+		uuid-dev \
 		gnupg \
 		gosu \
 		dirmngr \
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
+	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
 	make && \
 	make install all && \
 	cd contrib && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,6 +11,7 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline-dev \
+		uuid-dev \
 		gnupg \
 		gosu \
 		dirmngr \
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
+	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
 	make && \
 	make install all && \
 	cd contrib && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,14 +1,4 @@
 #!/usr/bin/env bash
 
-docker build --file 9.6/Dockerfile -t cimg/postgres:9.6.23  -t cimg/postgres:9.6 .
-docker build --file 9.6/postgis/Dockerfile -t cimg/postgres:9.6.23-postgis  -t cimg/postgres:9.6-postgis .
-docker build --file 10.18/Dockerfile -t cimg/postgres:10.18 .
-docker build --file 10.18/postgis/Dockerfile -t cimg/postgres:10.18-postgis .
-docker build --file 11.13/Dockerfile -t cimg/postgres:11.13 .
-docker build --file 11.13/postgis/Dockerfile -t cimg/postgres:11.13-postgis .
-docker build --file 12.8/Dockerfile -t cimg/postgres:12.8 .
-docker build --file 12.8/postgis/Dockerfile -t cimg/postgres:12.8-postgis .
 docker build --file 13.4/Dockerfile -t cimg/postgres:13.4 .
 docker build --file 13.4/postgis/Dockerfile -t cimg/postgres:13.4-postgis .
-docker build --file 14.0/Dockerfile -t cimg/postgres:14.0 .
-docker build --file 14.0/postgis/Dockerfile -t cimg/postgres:14.0-postgis .


### PR DESCRIPTION
This adds support for the uuid-ossp extension. Before rolling it out to all images (at 2-part respin process), just update the most recent image first so that users can test.