### PR TITLE
Align compile opts w/ Debian pkg [release]

### DIFF
--- a/13.4/Dockerfile
+++ b/13.4/Dockerfile
@@ -10,19 +10,64 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		libreadline-dev \
-		uuid-dev \
+		clang \
+		dirmngr \
 		gnupg \
 		gosu \
-		dirmngr \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		libpam-dev \
+		libperl-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
-	make && \
-	make install all && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
 	cd contrib && \
+	make && \
+	make install && \
+	cd xml2 && \
 	make && \
 	make install
 

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -10,18 +10,64 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		libreadline-dev \
+		clang \
+		dirmngr \
 		gnupg \
 		gosu \
-		dirmngr \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		libpam-dev \
+		libperl-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
-	make && \
-	make install all && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
 	cd contrib && \
+	make && \
+	make install && \
+	cd xml2 && \
 	make && \
 	make install
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,19 +10,64 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		libreadline-dev \
-		uuid-dev \
+		clang \
+		dirmngr \
 		gnupg \
 		gosu \
-		dirmngr \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		libpam-dev \
+		libperl-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
-	make && \
-	make install all && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
 	cd contrib && \
+	make && \
+	make install && \
+	cd xml2 && \
 	make && \
 	make install
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+docker build --file 9.6/Dockerfile -t cimg/postgres:9.6.23  -t cimg/postgres:9.6 .
+docker build --file 9.6/postgis/Dockerfile -t cimg/postgres:9.6.23-postgis  -t cimg/postgres:9.6-postgis .
 docker build --file 13.4/Dockerfile -t cimg/postgres:13.4 .
 docker build --file 13.4/postgis/Dockerfile -t cimg/postgres:13.4-postgis .


### PR DESCRIPTION
After PostgreSQL "common" extensions, then uuid-ossp, and then xml support, there's clearly a lot of extension support that was missing from this image. I went ahead and tracked down some Debian source packages and took a peak and what options they are enabling for their compiling of the PG packages. This is the result.

Like the PR from earlier today, this PR will re-spin PostgreSQL 13.4 to test with some customers. We're also respining 9.6.23 here for additional tests, especially for the issue in #17.

If the feedback from this is good, we will begin respinning the other images bringing the changes from this PR and #19 to all images.