### PR TITLE
Build Postgres 9.6 images in addition to 13.4

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+docker build --file 9.6/Dockerfile -t cimg/postgres:9.6.23  -t cimg/postgres:9.6 .
+docker build --file 9.6/postgis/Dockerfile -t cimg/postgres:9.6.23-postgis  -t cimg/postgres:9.6-postgis .
 docker build --file 13.4/Dockerfile -t cimg/postgres:13.4 .
 docker build --file 13.4/postgis/Dockerfile -t cimg/postgres:13.4-postgis .


### PR DESCRIPTION
This PR https://github.com/CircleCI-Public/cimg-postgres/pull/20 made some changes and as part of it, rebuilt 9.6 images. But then the changes were backed out in this PR https://github.com/CircleCI-Public/cimg-postgres/pull/22 due to issues. The back out change also removed the build commands for postgres 9.6 which resulted in just 13.4 getting rebuilt which undid the changes whereas 9.6 stuck with broken builds.

I am seeing error saying Postgres can't connect to Postgres Unix socket, same as here https://github.com/CircleCI-Public/cimg-postgres/issues/17#issuecomment-970113236

This PR adds those commands to rebuilt 9.6 images as well so users of Postgres 9.6 also have a working image.