### PR TITLE
Align compile opts w/ Debian pkg [release]

### DIFF
--- a/13.4/Dockerfile
+++ b/13.4/Dockerfile
@@ -19,7 +19,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
+	cd contrib && \
 	make && \
 	make install all && \
 	cd contrib && \

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -11,6 +11,7 @@ ENV POSTGRES_HOST_AUTH_METHOD=trust
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libreadline-dev \
+		uuid-dev \
 		gnupg \
 		gosu \
 		dirmngr \
@@ -18,7 +19,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
+	cd contrib && \
 	make && \
 	make install all && \
 	cd contrib && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,7 +19,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
 	cd postgresql-${PG_VER} && \
-	./configure --prefix=/usr/lib/postgresql/$PG_MAJOR --with-uuid=e2fs && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	make world-bin && \
+	make install-world-bin && \
+	cd contrib && \
 	make && \
 	make install all && \
 	cd contrib && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+docker build --file 9.6/Dockerfile -t cimg/postgres:9.6.23  -t cimg/postgres:9.6 .
+docker build --file 9.6/postgis/Dockerfile -t cimg/postgres:9.6.23-postgis  -t cimg/postgres:9.6-postgis .
 docker build --file 13.4/Dockerfile -t cimg/postgres:13.4 .
 docker build --file 13.4/postgis/Dockerfile -t cimg/postgres:13.4-postgis .


### PR DESCRIPTION
This PR is basically #20 however that ended up breaking the two images. The added configure option `--disable-rpath` was the culprit. #20 ended up being reverted in #22.

This PR reintroduces the changes, with the fix.