### PR TITLE
Roll extension changes to all images (p3) [release]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
               # an else block will be added in the future for a staging release
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/postgres to Docker Hub production."
-                docker push cimg/postgres
+                ./push-images.sh
               else
                 echo "Skipping publishing."
               fi

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker push cimg/postgres:9.6.23
+docker push cimg/postgres:9.6
+docker push cimg/postgres:9.6.23-postgis
+docker push cimg/postgres:9.6-postgis


### PR DESCRIPTION
This is basically #27 but built with an updated `shared-tools`. There's now a `push-images.sh` script file to push each specific image and tag one by one. This prevents issues where sometimes a tag won't push even though it was built, as well as another issue you can find in the PR in shared-tools.