### PR TITLE
10.20, 11.15, 13.6 and 14.2 images

### DIFF
--- a/10.20/Dockerfile
+++ b/10.20/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=10.20
+ENV PG_MAJOR=10
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/10.20/postgis/Dockerfile
+++ b/10.20/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:10.20
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/11.15/Dockerfile
+++ b/11.15/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=11.15
+ENV PG_MAJOR=11
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/11.15/postgis/Dockerfile
+++ b/11.15/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:11.15
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/13.6/Dockerfile
+++ b/13.6/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=13.6
+ENV PG_MAJOR=13
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/13.6/postgis/Dockerfile
+++ b/13.6/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:13.6
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/14.2/Dockerfile
+++ b/14.2/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=14.2
+ENV PG_MAJOR=14
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/14.2/postgis/Dockerfile
+++ b/14.2/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:14.2
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 11.14/Dockerfile -t cimg/postgres:11.14 .
-docker build --file 11.14/postgis/Dockerfile -t cimg/postgres:11.14-postgis .
-docker build --file 12.10/Dockerfile -t cimg/postgres:12.10 .
-docker build --file 12.10/postgis/Dockerfile -t cimg/postgres:12.10-postgis .
+docker build --file 10.20/Dockerfile -t cimg/postgres:10.20 .
+docker build --file 10.20/postgis/Dockerfile -t cimg/postgres:10.20-postgis .
+docker build --file 11.15/Dockerfile -t cimg/postgres:11.15 .
+docker build --file 11.15/postgis/Dockerfile -t cimg/postgres:11.15-postgis .
+docker build --file 13.6/Dockerfile -t cimg/postgres:13.6 .
+docker build --file 13.6/postgis/Dockerfile -t cimg/postgres:13.6-postgis .
+docker build --file 14.2/Dockerfile -t cimg/postgres:14.2 .
+docker build --file 14.2/postgis/Dockerfile -t cimg/postgres:14.2-postgis .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker push cimg/postgres:11.14
-docker push cimg/postgres:11.14-postgis
+docker push cimg/postgres:10.20
+docker push cimg/postgres:10.20-postgis
 
-docker push cimg/postgres:12.10
-docker push cimg/postgres:12.10-postgis
+docker push cimg/postgres:11.15
+docker push cimg/postgres:11.15-postgis
+
+docker push cimg/postgres:13.6
+docker push cimg/postgres:13.6-postgis
+
+docker push cimg/postgres:14.2
+docker push cimg/postgres:14.2-postgis


### PR DESCRIPTION
Adding [latest release](https://www.postgresql.org/about/news/postgresql-142-136-1210-1115-and-1020-released-2402/) images, with the exception of 12.10 as that has already been added by https://github.com/CircleCI-Public/cimg-postgres/pull/43.

Created using:

```sh
./shared/gen-dockerfiles.sh 10.20 11.15 13.6 14.2
./build-images.sh
git add . # commit, push etc
```