### PR TITLE
releases with patch for vulnerability CVE-2022-2625

### DIFF
--- a/10.22/Dockerfile
+++ b/10.22/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=10.22
+ENV PG_MAJOR=10
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/10.22/postgis/Dockerfile
+++ b/10.22/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:10.22
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/11.17/Dockerfile
+++ b/11.17/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=11.17
+ENV PG_MAJOR=11
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/11.17/postgis/Dockerfile
+++ b/11.17/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:11.17
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/12.12/Dockerfile
+++ b/12.12/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=12.12
+ENV PG_MAJOR=12
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/12.12/postgis/Dockerfile
+++ b/12.12/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:12.12
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/13.8/Dockerfile
+++ b/13.8/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=13.8
+ENV PG_MAJOR=13
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/13.8/postgis/Dockerfile
+++ b/13.8/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:13.8
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/14.5/Dockerfile
+++ b/14.5/Dockerfile
@@ -1,0 +1,94 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.08
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV PG_VER=14.5
+ENV PG_MAJOR=14
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		dirmngr \
+		gnupg \
+		gosu \
+		libclang-dev \
+		libicu-dev \
+		libipc-run-perl \
+		libkrb5-dev \
+		libldap2-dev \
+		liblz4-dev \
+		libpam-dev \
+		libperl-dev \
+		libpython3-dev \
+		libreadline-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt1-dev \
+		llvm \
+		llvm-dev \
+		locales \
+		python3-dev \
+		tcl-dev \
+		uuid-dev \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+	curl -sSL "https://ftp.postgresql.org/pub/source/v${PG_VER}/postgresql-${PG_VER}.tar.gz" | tar -xz && \
+	cd postgresql-${PG_VER} && \
+	./configure \
+		--prefix=/usr/lib/postgresql/$PG_MAJOR \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
+		--with-pam \
+		--with-tcl \
+		--with-perl \
+		--with-python \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+	&& \
+	# we can change from world to world-bin in newer releases
+	make world && \
+	make install-world
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+
+RUN useradd postgres -m -s /bin/bash && \
+	groupadd --force postgres && \
+	adduser postgres postgres
+
+ENV POSTGRES_DB=circle_test
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN mkdir -p /var/lib/postgresql && \
+	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+STOPSIGNAL SIGINT
+EXPOSE 5432
+CMD ["postgres"]

--- a/14.5/postgis/Dockerfile
+++ b/14.5/postgis/Dockerfile
@@ -1,0 +1,23 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/postgres:14.5
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV POSTGIS_VER=3.1.4
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libgdal-dev \
+		libgeos-dev \
+		libjson-c-dev \
+		libmysqlclient-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		libxml2-dev \
+		protobuf-c-compiler \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
+	cd postgis-${POSTGIS_VER} && \
+	./configure && \
+	make && \
+	make install

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 10.21/Dockerfile -t cimg/postgres:10.21 .
-docker build --file 10.21/postgis/Dockerfile -t cimg/postgres:10.21-postgis .
-docker build --file 11.16/Dockerfile -t cimg/postgres:11.16 .
-docker build --file 11.16/postgis/Dockerfile -t cimg/postgres:11.16-postgis .
-docker build --file 12.11/Dockerfile -t cimg/postgres:12.11 .
-docker build --file 12.11/postgis/Dockerfile -t cimg/postgres:12.11-postgis .
-docker build --file 13.7/Dockerfile -t cimg/postgres:13.7 .
-docker build --file 13.7/postgis/Dockerfile -t cimg/postgres:13.7-postgis .
-docker build --file 14.3/Dockerfile -t cimg/postgres:14.3 .
-docker build --file 14.3/postgis/Dockerfile -t cimg/postgres:14.3-postgis .
-docker build --file 14.4/Dockerfile -t cimg/postgres:14.4 .
-docker build --file 14.4/postgis/Dockerfile -t cimg/postgres:14.4-postgis .
+docker build --file 10.22/Dockerfile -t cimg/postgres:10.22 .
+docker build --file 10.22/postgis/Dockerfile -t cimg/postgres:10.22-postgis .
+docker build --file 11.17/Dockerfile -t cimg/postgres:11.17 .
+docker build --file 11.17/postgis/Dockerfile -t cimg/postgres:11.17-postgis .
+docker build --file 12.12/Dockerfile -t cimg/postgres:12.12 .
+docker build --file 12.12/postgis/Dockerfile -t cimg/postgres:12.12-postgis .
+docker build --file 13.8/Dockerfile -t cimg/postgres:13.8 .
+docker build --file 13.8/postgis/Dockerfile -t cimg/postgres:13.8-postgis .
+docker build --file 14.5/Dockerfile -t cimg/postgres:14.5 .
+docker build --file 14.5/postgis/Dockerfile -t cimg/postgres:14.5-postgis .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker push cimg/postgres:10.21
-docker push cimg/postgres:10.21-postgis
+docker push cimg/postgres:10.22
+docker push cimg/postgres:10.22-postgis
 
-docker push cimg/postgres:11.16
-docker push cimg/postgres:11.16-postgis
+docker push cimg/postgres:11.17
+docker push cimg/postgres:11.17-postgis
 
-docker push cimg/postgres:12.11
-docker push cimg/postgres:12.11-postgis
+docker push cimg/postgres:12.12
+docker push cimg/postgres:12.12-postgis
 
-docker push cimg/postgres:13.7
-docker push cimg/postgres:13.7-postgis
+docker push cimg/postgres:13.8
+docker push cimg/postgres:13.8-postgis
 
-docker push cimg/postgres:14.3
-docker push cimg/postgres:14.3-postgis
-
-docker push cimg/postgres:14.4
-docker push cimg/postgres:14.4-postgis
+docker push cimg/postgres:14.5
+docker push cimg/postgres:14.5-postgis


### PR DESCRIPTION
releases 10.22 11.17 12.12 13.8 14.5 to make available the patch for CVE-2022-2625