### PR TITLE
fix setting of custom PGDATA

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,7 +87,7 @@ docker_init_database_dir() {
 		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
 	fi
 
-	echo "listen_addresses = '*'" >> /var/lib/postgresql/data/postgresql.conf
+	echo "listen_addresses = '*'" >> "$PGDATA/postgresql.conf"
 }
 
 # print large warning if POSTGRES_PASSWORD is long


### PR DESCRIPTION
Currently the PGDATA path is hardcoded for setting the `listen_addresses`, this fix allows using the custom PGDATA passed through.

Fixes: https://github.com/CircleCI-Public/cimg-postgres/issues/55
