### PR TITLE
Update PostGIS to v3.2.4

### DIFF
--- a/variants/postgis.Dockerfile.template
+++ b/variants/postgis.Dockerfile.template
@@ -4,7 +4,7 @@ FROM cimg/%%PARENT%%:%%PARENT_TAG%%
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV POSTGIS_VER=3.1.4
+ENV POSTGIS_VER=3.2.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libgdal-dev \
 		libgeos-dev \


### PR DESCRIPTION
Fixes #57

We will upgrade to v3.3.x or v3.4.x in the new year.