### PR TITLE
Add pg_cron, install to postgres database in image build

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	make install-world && \
 	# clones pg_cron extension for local use, this is not available wihout installing
  	git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
-	cd pg_cron  make && make install && \
+	cd pg_cron && make && make install && \
 	cron_conf=/var/lib/postgresql/data/custom-conf.conf && echo "" > $cron_conf && \
 	echo "shared_preload_libraries = 'pg_cron'" >> $cron_conf && \
 	echo "cron.database_name = 'postgres'" >> $cron_conf && \
@@ -85,8 +85,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	if [ -z "$found" ]; then \ 
 	  echo "include = '$cron_conf'" >> /var/lib/postgresql/data/postgresql.conf \
 	fi 
-	
-
 	
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -88,9 +88,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	
 RUN mkdir /docker-entrypoint-initdb.d
 
-# copies install script into entrypoint directory to initialize and expose pg_cron on start up
-
-
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	found=$(grep "include = '$cron_conf'" /var/lib/postgresql/data/postgresql.conf) && \
 	# if the cron_conf is not in the postgresql.conf file, we add it to the file before continuing.
 	if [ -z "$found" ]; then 
-	  echo "include = '$cron_conf'" >> /var/lib/postgresql/data/postgresql.conf \
+	  echo "include = '$cron_conf'" >> /var/lib/postgresql/data/postgresql.conf 
 	fi 
 	
 RUN mkdir /docker-entrypoint-initdb.d

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -71,9 +71,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& \
 	# we can change from world to world-bin in newer releases
 	make world && \
-	make install-world
+	make install-world && \
+	# clones pg_cron extension for local use, this is not available wihout installing
+ 	git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
+	cd pg_cron  make && make install
 
 RUN mkdir /docker-entrypoint-initdb.d
+
+# copies install script into entrypoint directory to initialize and expose pg_cron on start up
+COPY assets/pg_cron.sh /docker-entrypoint-initdb.d
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -80,8 +80,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	echo "cron.database_name = 'postgres'" >> $customconf && \
 	chown postgres $customconf && \
 	chgrp postgres $customconf && \ 
-	conf=/var/lib/postgresql/data/postgresql.conf && \
-	found=$(grep "include = '$customconf'" $conf) && \
+	found=$(grep "include = '$customconf'" /var/lib/postgresql/data/postgresql.conf) && \
+	# if the custom conf is not in the postgresql.conf file, we add it to the file before continuing.
 	if [ -z "$found" ]; then \ 
 	  echo "include = '$customconf'" >> $conf \
 	fi 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,12 +74,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	make install-world && \
 	# clones pg_cron extension for local use, this is not available wihout installing
  	git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
-	cd pg_cron  make && make install
+	cd pg_cron  make && make install && \
+	customconf=/var/lib/postgresql/data/custom-conf.conf && echo "" > $customconf && \
+	echo "shared_preload_libraries = 'pg_cron'" >> $customconf && \
+	echo "cron.database_name = 'postgres'" >> $customconf && \
+	chown postgres $customconf && \
+	chgrp postgres $customconf && \ 
+	conf=/var/lib/postgresql/data/postgresql.conf && \
+	found=$(grep "include = '$customconf'" $conf) && \
+	if [ -z "$found" ]; then \ 
+	  echo "include = '$customconf'" >> $conf \
+	fi 
+	
 
+	
 RUN mkdir /docker-entrypoint-initdb.d
 
 # copies install script into entrypoint directory to initialize and expose pg_cron on start up
-COPY assets/pg_cron.sh /docker-entrypoint-initdb.d
+
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -79,10 +79,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	echo "shared_preload_libraries = 'pg_cron'" >> $cron_conf && \
 	echo "cron.database_name = 'postgres'" >> $cron_conf && \
 	chown postgres $cron_conf && \
-	chgrp postgres $cron_conf && \ 
+	chgrp postgres $cron_conf && \
 	found=$(grep "include = '$cron_conf'" /var/lib/postgresql/data/postgresql.conf) && \
 	# if the cron_conf is not in the postgresql.conf file, we add it to the file before continuing.
-	if [ -z "$found" ]; then \ 
+	if [ -z "$found" ]; then 
 	  echo "include = '$cron_conf'" >> /var/lib/postgresql/data/postgresql.conf \
 	fi 
 	

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -75,15 +75,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	# clones pg_cron extension for local use, this is not available wihout installing
  	git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
 	cd pg_cron  make && make install && \
-	customconf=/var/lib/postgresql/data/custom-conf.conf && echo "" > $customconf && \
-	echo "shared_preload_libraries = 'pg_cron'" >> $customconf && \
-	echo "cron.database_name = 'postgres'" >> $customconf && \
-	chown postgres $customconf && \
-	chgrp postgres $customconf && \ 
-	found=$(grep "include = '$customconf'" /var/lib/postgresql/data/postgresql.conf) && \
-	# if the custom conf is not in the postgresql.conf file, we add it to the file before continuing.
+	cron_conf=/var/lib/postgresql/data/custom-conf.conf && echo "" > $cron_conf && \
+	echo "shared_preload_libraries = 'pg_cron'" >> $cron_conf && \
+	echo "cron.database_name = 'postgres'" >> $cron_conf && \
+	chown postgres $cron_conf && \
+	chgrp postgres $cron_conf && \ 
+	found=$(grep "include = '$cron_conf'" /var/lib/postgresql/data/postgresql.conf) && \
+	# if the cron_conf is not in the postgresql.conf file, we add it to the file before continuing.
 	if [ -z "$found" ]; then \ 
-	  echo "include = '$customconf'" >> $conf \
+	  echo "include = '$cron_conf'" >> /var/lib/postgresql/data/postgresql.conf \
 	fi 
 	
 


### PR DESCRIPTION
- clones and installs pg_cron.
- writes a custom conf file which installs pg_cron and makes it available for `create extension pg_cron;`
- pg_cron exposes the crontab on the linux instance under postgresql allowing users to schedule work. 
- this is a common installation option in RDS and useful for local testing