### PR TITLE
Refactor/use cimg orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,88 +1,67 @@
 version: 2.1
 
 orbs:
-  sonar: hubci/sonar@1.0.0
+  cimg: circleci/cimg@0.3.0
 
 workflows:
-  main:
+  main-wf:
     jobs:
-      - build:
+      - cimg/build-and-deploy:
+          name: "Staging"
+          docker-namespace: ccitest
+          docker-repository: postgres
+          publish-branch: test
+          filters:
+            branches:
+              ignore:
+                - main
+          post-steps:
+            - run:
+                name: Install Prerequisites
+                command: |
+                  sudo apt-get update && \
+                  sudo apt-get install -y postgresql-client
+            - run:
+                name: Test Docker Images
+                shell: /bin/bash -o pipefail
+                command: |
+                  ssh -f -N -L localhost:5432:localhost:5432 remote-docker
+                  IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "ccitest/postgres")
+                  for IMAGE in $IMAGES; do
+                    printf "Booting $IMAGE...\n"
+                    CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE)
+                    for i in {1..20}; do
+                      printf "[$i/20] Checking Postgres is up...\n"
+                      pg_isready -h 127.0.0.1
+                      if [ $? -eq 0 ]; then
+                        printf "Booted $IMAGE!\n"
+                        break
+                      elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
+                        printf "Failed to boot image\n"
+                        exit 1
+                      fi
+                      printf "[$i/20] No response. Sleeping 10s...\n"
+                      sleep 10s
+                    done
+                    printf "Running Test Command...\n"
+                    printf "Running Version Check...\n"
+                    VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
+                    if PGPASSWORD=passw0rd psql -h 127.0.0.1 -U user postgres -c "SELECT VERSION();" | grep $VERSION ; then
+                      printf "Version matches!\n"
+                    else
+                      printf "Version mismatch!\n"
+                      exit 1
+                    fi
+                    printf "Stopping $IMAGE...\n"
+                    docker stop $CONTAINER_ID >/dev/null 2>&1
+                  done
+                  printf "All images passed!\n"
           context: cimg-publishing
-
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2022.01
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "20.10.11"
-      - run:
-          name: "Build Docker Images"
-          command: |
-            ./build-images.sh
-            docker images
-            echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
-      - run:
-          name: "Install Test Prerequisites"
-          command: |
-            sudo apt-get update && \
-            sudo apt-get install -y postgresql-client
-      - run:
-          name: "Test Docker Images"
-          shell: /bin/bash -o pipefail
-          command: |
-            ssh -f -N -L localhost:5432:localhost:5432 remote-docker
-            IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "cimg/postgres")
-            for IMAGE in $IMAGES; do
-              printf "Booting $IMAGE...\n"
-              CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE)
-              for i in {1..20}; do
-                printf "[$i/20] Checking Postgres is up...\n"
-                pg_isready -h 127.0.0.1 -q
-                if [ $? -eq 0 ]; then
-                  printf "Booted $IMAGE!\n"
-                  break
-                elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
-                  printf "Failed to boot image\n"
-                  exit 1
-                fi
-                printf "[$i/20] No response. Sleeping 10s...\n"
-                sleep 10s
-              done
-              printf "Running Test Command...\n"
-              printf "Running Version Check...\n"
-              VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
-              if PGPASSWORD=passw0rd psql -h 127.0.0.1 -U user postgres -c "SELECT VERSION();" | grep $VERSION ; then
-                printf "Version matches!\n"
-              else
-                printf "Version mismatch!\n"
-                exit 1
-              fi
-              printf "Stopping $IMAGE...\n"
-              docker stop $CONTAINER_ID >/dev/null 2>&1
-            done
-            printf "All images passed!\n"
-      - deploy:
-          name: "Publish Docker Images (main branch only)"
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              
-              # an else block will be added in the future for a staging release
-              if git log -1 --pretty=%s | grep "\[release\]"; then
-                echo "Publishing cimg/postgres to Docker Hub production."
-                ./push-images.sh
-              else
-                echo "Skipping publishing."
-              fi
-            fi
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            - sonar/install:
-                version: "0.15.0"
-            - sonar/update-readme:
-                image: cimg/postgres
+      - cimg/build-and-deploy:
+          name: "Deploy"
+          docker-repository: postgres
+          filters:
+            branches:
+              only:
+                - main
+          context: cimg-publishing


### PR DESCRIPTION
- migrates build to cimg-orb
- postgres check is now added as a post-step to the build only for the test build, which should also cut down on overall build times when merged into main