### PR TITLE
feat: implement pg_cron capabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
                   IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "ccitest/postgres")
                   for IMAGE in $IMAGES; do
                     printf "Booting $IMAGE...\n"
-                    CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/etc/postgresql/postgresql.conf')
+                    CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/var/lib/postgresql/data/postgresql.conf')
                     for i in {1..20}; do
                       printf "[$i/20] Checking Postgres is up...\n"
                       pg_isready -h 127.0.0.1

--- a/12.13/Dockerfile
+++ b/12.13/Dockerfile
@@ -6,13 +6,16 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/base:2023.01
+FROM cimg/base:2023.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 ENV PG_VER=12.13
 ENV PG_MAJOR=12
 ENV POSTGRES_HOST_AUTH_METHOD=trust
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+ENV POSTGRES_DB=circle_test
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -36,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		llvm \
 		llvm-dev \
 		locales \
+		postgresql-server-dev-all \
 		python3-dev \
 		tcl-dev \
 		uuid-dev \
@@ -73,25 +77,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	make world && \
 	make install-world
 
+# clones pg_cron extension for local use, this is not available wihout installing
+# run this as a separate layer so it caches better
+RUN git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
+	cd /pg_cron && make && PATH=$PATH make install
+
 RUN mkdir /docker-entrypoint-initdb.d
 
-ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
-ENV PGDATA /var/lib/postgresql/data
-
-RUN useradd postgres -m -s /bin/bash && \
-	groupadd --force postgres && \
-	adduser postgres postgres
-
-ENV POSTGRES_DB=circle_test
-
-COPY postgresql.conf /etc/postgresql/postgresql.conf
+COPY pg_cron.sh /docker-entrypoint-initdb.d/
+COPY custom-postgresql.conf /etc/postgresql/custom-postgresql.conf
 COPY docker-entrypoint.sh /usr/local/bin/
+
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /docker-entrypoint-initdb.d/pg_cron.sh
 RUN mkdir -p /var/lib/postgresql && \
 	chown -R postgres:postgres /var/lib/postgresql && \
-	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
+	rm -rf /pg_cron
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 STOPSIGNAL SIGINT

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,6 +13,9 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 ENV PG_VER=%%VERSION_FULL%%
 ENV PG_MAJOR=%%VERSION_MAJOR%%
 ENV POSTGRES_HOST_AUTH_METHOD=trust
+ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
+ENV PGDATA /var/lib/postgresql/data
+ENV POSTGRES_DB=circle_test
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -36,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		llvm \
 		llvm-dev \
 		locales \
+		postgresql-server-dev-all \
 		python3-dev \
 		tcl-dev \
 		uuid-dev \
@@ -73,25 +77,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	make world && \
 	make install-world
 
+# clones pg_cron extension for local use, this is not available wihout installing
+# run this as a separate layer so it caches better
+RUN git clone https://github.com/citusdata/pg_cron.git /pg_cron && \
+	cd /pg_cron && make && PATH=$PATH make install
+
 RUN mkdir /docker-entrypoint-initdb.d
 
-ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
-ENV PGDATA /var/lib/postgresql/data
-
-RUN useradd postgres -m -s /bin/bash && \
-	groupadd --force postgres && \
-	adduser postgres postgres
-
-ENV POSTGRES_DB=circle_test
-
-COPY postgresql.conf /etc/postgresql/postgresql.conf
+COPY pg_cron.sh /docker-entrypoint-initdb.d/
+COPY custom-postgresql.conf /etc/postgresql/custom-postgresql.conf
 COPY docker-entrypoint.sh /usr/local/bin/
+
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /docker-entrypoint-initdb.d/pg_cron.sh
 RUN mkdir -p /var/lib/postgresql && \
 	chown -R postgres:postgres /var/lib/postgresql && \
-	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
+	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
+	rm -rf /pg_cron
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 STOPSIGNAL SIGINT

--- a/custom-postgresql.conf
+++ b/custom-postgresql.conf
@@ -4,3 +4,5 @@ max_prepared_transactions = 200
 max_locks_per_transaction = 512
 max_pred_locks_per_transaction = 256
 listen_addresses = '*'
+shared_preload_libraries = 'pg_cron'
+cron.database_name = 'circle_test'

--- a/pg_cron.sh
+++ b/pg_cron.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# use same db as the one from env
+dbname="$POSTGRES_DB"
+
+# create custom config
+customconf=/etc/postgresql/custom-postgresql.conf
+echo "shared_preload_libraries = 'pg_cron'" >> $customconf
+echo "cron.database_name = '$dbname'" >> $customconf
+chown postgres $customconf
+chgrp postgres $customconf
+
+cat /etc/postgresql/custom-postgresql.conf
+
+# include custom config from main config
+conf=/var/lib/postgresql/data/postgresql.conf
+found=$(grep "include = '$customconf'" $conf)
+if [ -z "$found" ]; then
+  echo "include = '$customconf'" >> $conf
+fi
+
+cat /var/lib/postgresql/data/postgresql.conf | grep shared
+cat /var/lib/postgresql/data/postgresql.conf | grep include


### PR DESCRIPTION
- adds code to install pg_cron extension
- allows user to modify the custom configuration
- moves all ENVs to top layers
- custom-postgressql.conf can be editable by all users who want to extend
- pg_cron.sh does not need to be limited to pg_cron
- additional features we are investigating are the additional of additional modules + enabling them 