### PR TITLE
feat: enables postgis out of the box in the template

### DIFF
--- a/variants/postgis.Dockerfile.template
+++ b/variants/postgis.Dockerfile.template
@@ -20,4 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	cd postgis-${POSTGIS_VER} && \
 	./configure && \
 	make && \
-	make install
+	make install && \
+	echo "CREATE EXTENSION postgis;" > /docker-entrypoint-initdb.d/postgis.sql
+


### PR DESCRIPTION
Enables postgis out of the box, without needed to go into the database and enable the postgis extension. Closes #79