### PR TITLE
feat: add support for PG Partman

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -17,6 +17,7 @@ ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 ENV POSTGRES_DB=circle_test
 ENV PGTAP_VERSION 1.2.0
+ENV PARTMAN_VERSION 4.7.2
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -77,6 +78,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	# we can change from world to world-bin in newer releases
 	make world && \
 	make install-world
+
+RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${PARTMAN_VERSION}.tar.gz" | tar -xz && \
+	cd pg_partman-${PARTMAN_VERSION} && make NO_BGW=1 install
 
 # clones pg_cron extension for local use, this is not available wihout installing
 # run this as a separate layer so it caches better


### PR DESCRIPTION
# Description

This adds PG Partman support to the base image. 

From https://github.com/pgpartman/pg_partman:

> pg_partman is an extension to create and manage both time-based and
> serial-based table partition sets. Native partitioning in PostgreSQL
> 10 is supported as of pg_partman v3.0.1 and much more extensively as
> of 4.0.0 along with PostgreSQL 11.

I opted to not install the background worker, since the base image already has pg_cron.

## Size changes
This appears to add about 20 MB to the base image size, when building as a separate layer:
```
$ docker image ls | grep cimg/post
cimg/postgres               12.9-partman          586ec1dac200   About an hour ago   2.1GB
cimg/postgres               12.9                  37dfce59e2e3   18 months ago       2.08GB
```

# Reasons
I would like to use Partman for local development and in CI so that my schema can match the production version.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
