### PR TITLE
Minor fix to README for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ The generated Dockerfile will be located at `./13.2/Dockefile`.
 To build this image locally and try it out, you can run the following:
 
 ```bash
-cd 13.2
-docker build -t test/postgres:13.2 .
+docker build -f 13.2/Dockerfile -t test/postgres:13.2 .
 docker run -it test/postgres:13.2 bash
 ```
 


### PR DESCRIPTION
# Description
Fix instruction for building docker file locally.

# Reasons
Attempting to follow the existing instructions resulted in like these:

> ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref moby::n121hzsjwlavfwipi9m4394vk: "/docker-entrypoint.sh": not found

This is because the file is in the root of the repo, so the command must be run from that location. 

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] ~I have made changes to the `Dockerfile.template` file only~ (N/A)
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
