### PR TITLE
Purge build deps to shrink the 12.15 image from 2.47 GB to 1.76 GB

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,11 +20,9 @@ ENV PGTAP_VERSION 1.2.0
 ENV PARTMAN_VERSION 4.7.2
 
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		clang \
+RUN BUILD_DEPS="clang \
 		dirmngr \
 		gnupg \
-		gosu \
 		libclang-dev \
 		libicu-dev \
 		libipc-run-perl \
@@ -40,11 +38,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libxslt1-dev \
 		llvm \
 		llvm-dev \
-		locales \
 		postgresql-server-dev-all \
 		python3-dev \
 		tcl-dev \
-		uuid-dev \
+		uuid-dev" && \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gosu \
+	locales \
+	$BUILD_DEPS \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
@@ -78,17 +79,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	# we can change from world to world-bin in newer releases
 	make world && \
 	make install-world && \
-	cd .. && rm -rf postgresql-${PG_VER}
+	cd .. && rm -rf postgresql-${PG_VER} \
+	&& \
+	git clone --depth 1 https://github.com/citusdata/pg_cron.git /pg_cron && \
+	cd /pg_cron && make && PATH=$PATH make install && \
+	rm -rf /pg_cron && \
+	apt-get purge -y --auto-remove $BUILD_DEPS
 
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${PARTMAN_VERSION}.tar.gz" | tar -xz && \
 	cd pg_partman-${PARTMAN_VERSION} && make NO_BGW=1 install && \
 	cd .. && rm -rf pg_partman-${PARTMAN_VERSION}
-
-# clones pg_cron extension for local use, this is not available wihout installing
-# run this as a separate layer so it caches better
-RUN git clone --depth 1 https://github.com/citusdata/pg_cron.git /pg_cron && \
-	cd /pg_cron && make && PATH=$PATH make install && \
-	rm -rf /pg_cron
 
 # Install pgTAP & pg_prove utility.
 RUN git clone --depth 1 -b "v$PGTAP_VERSION" https://github.com/theory/pgtap.git /pgtap && \


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description

Purge build deps to shrink image from 2.42 GB to 1.76 GB

The space savings are for the 12.15 image, built locally with this commit compared with the latest published version.

Combine the pg and pg_cron layers to avoid installing & purging build-depends several times.

Gosu is used in entrypoint, so it is not purged.
locales is required by Pg at runtime, so it is not purged. 

```
~/src/cimg-postgres $ docker image ls | awk 'NR==1 || /12.15/'
REPOSITORY           TAG               IMAGE ID       CREATED         SIZE
stigbra/postgres     12.15             635b39e20ee4   11 hours ago    1.76GB
stigbra/postgres     12.15-before      e80aef4f7f05   6 hours ago     2.47GB
cimg/postgres        12.15             2ddb6adf99f3   5 weeks ago     2.42GB
```

- `cimg/postgres` is the most recently published that I pulled down from Docker Hub. 
- `12.15-before` is an image I built from the commit immediately before the one I'm adding here
- `12.15` is with this commit
 
# Reasons
I want to shrink the postgresql image sizes. This should improve spin-up time a little, especially if the image is not in the local Docker Layer Cache. It also helps for local development.

I achieved the space savings by installing & purging build-time dependencies in the postgres and pg_cron installation steps.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
