### PR TITLE
remove pgtap being enabled by default

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -97,13 +97,12 @@ RUN git clone --depth 1 -b "v$PGTAP_VERSION" https://github.com/theory/pgtap.git
 	cpanm -n TAP::Parser::SourceHandler::pgTAP && \
 	rm -rf /pgtap
 
-# Enable extensions
-RUN mkdir /docker-entrypoint-initdb.d && \
-	echo "CREATE EXTENSION pgtap;" > /docker-entrypoint-initdb.d/pgtap.sql
-COPY pg_cron.sh /docker-entrypoint-initdb.d/
+RUN mkdir /docker-entrypoint-initdb.d
 
+COPY pg_cron.sh /docker-entrypoint-initdb.d/
 COPY custom-postgresql.conf /etc/postgresql/custom-postgresql.conf
 COPY docker-entrypoint.sh /usr/local/bin/
+
 # Backwards compatibility
 RUN ln -s usr/local/bin/docker-entrypoint.sh /
 
@@ -111,7 +110,6 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh /docker-entrypoint-initdb.d/pg_
 	mkdir -p /var/lib/postgresql && \
 	chown -R postgres:postgres /var/lib/postgresql && \
 	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
-
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 STOPSIGNAL SIGINT

--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ When releasing proper images for CircleCI, this script is run from a CircleCI pi
 ## Configuration
 
 Because some configurations for postgres are enabled at runtime, it is difficult if not impossible to change certain settings.
-As a result, we've provided a configuration file within this repository that allows you to import certain properties that can support your use case. This is located at the project root under `postgres.conf`, however, you would be able to supply a custom configuration file yourself. In doing so, you would also need to specify this file when running the docker container.
+As a result, we've provided a configuration file within this repository that allows you to import certain properties that can support your use case. This is located at the project root under `custom-postgres.conf`, however, you would be able to supply a custom configuration file yourself. In doing so, you would also need to specify this file when running the docker container.
 
 For example, in the `.circleci/config.yml`, we are using it with this command; specifically, the "postgres -c 'config_file=xxx'" addition.
+
+Please note there are additions to this file, such as `shared_preload_libraries` that may not be needed.
 
 ```bash
 docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/etc/postgresql/postgresql.conf'
@@ -211,6 +213,8 @@ New Go images will automatically pick up the changes.
 
 If you *really* want to publish changes from a parent image into the PostgreSQL image, you have to build a specific image version as if it was a new image.
 This will create a new Dockerfile and once published, a new image.
+
+Extensions in the parent image will **not** have extensions enabled by default. This should be done by the user. Please refer to respective README's on how to enable, but the general idea would be to create a `*.sql` file in `/docker-entrypoint-initdb.d/` along with custom configurations, which can be referred to in the configurations section of the README
 
 **PostgreSQL specific changes** - Editing the `Dockerfile.template` file in this repo will modify the PostgreSQL image specifically.
 Don't forget that to see any of these changes locally, the `gen-dockerfiles.sh` script will need to be run again (see above).


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Installs but disables pgtap extension by default

# Reasons
Removes enabling pgtap by default, which can break user builds, especially when they are using pgtap with historical changes. With this, all extensions and configurations should be created by the user for their needs.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
