### PR TITLE
Allow pg_cron to work on any configured POSTGRES_DB

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -109,6 +109,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh /
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /docker-entrypoint-initdb.d/pg_cron.sh && \
 	mkdir -p /var/lib/postgresql && \
 	chown -R postgres:postgres /var/lib/postgresql && \
+	chown -R postgres:postgres /etc/postgresql && \
 	chown -R postgres:postgres /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/custom-postgresql.conf
+++ b/custom-postgresql.conf
@@ -4,5 +4,3 @@ max_prepared_transactions = 200
 max_locks_per_transaction = 512
 max_pred_locks_per_transaction = 256
 listen_addresses = '*'
-shared_preload_libraries = 'pg_cron'
-cron.database_name = 'circle_test'


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
This fixes ownership of the files in the /etc/postgresql directory, so the pg_cron.sh script can amend these files as it expects to do. 

# Reasons
Due to incorrect ownership of /etc/postgresql/custom-postgresql.conf the pg_cron.sh script was not able to add POSTGRES_DB to the `cron.database_name` config. Thus the only DB that would work with pg_cron is the 'circle_test' DB, as this was hard-coded in the example file.

This fixes ownership of the files in the /etc/postgresql directory, so the pg_cron.sh script can run without errors.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
