### PR TITLE
Add Arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ workflows:
     jobs:
       - cimg/build-and-deploy:
           name: "Staging"
+          resource-class: 2xlarge+
           docker-namespace: ccitest
           docker-repository: postgres
           publish-branch: test
@@ -30,47 +31,7 @@ workflows:
             branches:
               ignore:
                 - main
-          # post-steps:
-          #   - run:
-          #       name: Install Prerequisites
-          #       command: |
-          #         sudo apt-get update && \
-          #         sudo apt-get install -y postgresql-client
-          #   - run:
-          #       name: Test Docker Images
-          #       shell: /bin/bash -o pipefail
-          #       command: |
-          #         ssh -f -N -L localhost:5432:localhost:5432 remote-docker
-          #         IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "ccitest/postgres")
-          #         for IMAGE in $IMAGES; do
-          #           printf "Booting $IMAGE...\n"
-          #           CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/var/lib/postgresql/data/postgresql.conf')
-          #           for i in {1..20}; do
-          #             printf "[$i/20] Checking Postgres is up...\n"
-          #             pg_isready -h 127.0.0.1
-          #             if [ $? -eq 0 ]; then
-          #               printf "Booted $IMAGE!\n"
-          #               break
-          #             elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
-          #               printf "Failed to boot image\n"
-          #               exit 1
-          #             fi
-          #             printf "[$i/20] No response. Sleeping 10s...\n"
-          #             sleep 10s
-          #           done
-          #           printf "Running Test Command...\n"
-          #           printf "Running Version Check...\n"
-          #           VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
-          #           if PGPASSWORD=passw0rd psql -h 127.0.0.1 -U user postgres -c "SELECT VERSION();" | grep $VERSION ; then
-          #             printf "Version matches!\n"
-          #           else
-          #             printf "Version mismatch!\n"
-          #             exit 1
-          #           fi
-          #           printf "Stopping $IMAGE...\n"
-          #           docker stop $CONTAINER_ID >/dev/null 2>&1
-          #         done
-          #         printf "All images passed!\n"
+          post-steps:
             - slack/notify:
                 branch_pattern: release-v.+
                 event: pass
@@ -79,6 +40,7 @@ workflows:
           context: cimg-publishing
       - cimg/build-and-deploy:
           name: "Deploy"
+          resource-class: 2xlarge+
           docker-repository: postgres
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.4
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,47 +30,47 @@ workflows:
             branches:
               ignore:
                 - main
-          post-steps:
-            - run:
-                name: Install Prerequisites
-                command: |
-                  sudo apt-get update && \
-                  sudo apt-get install -y postgresql-client
-            - run:
-                name: Test Docker Images
-                shell: /bin/bash -o pipefail
-                command: |
-                  ssh -f -N -L localhost:5432:localhost:5432 remote-docker
-                  IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "ccitest/postgres")
-                  for IMAGE in $IMAGES; do
-                    printf "Booting $IMAGE...\n"
-                    CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/var/lib/postgresql/data/postgresql.conf')
-                    for i in {1..20}; do
-                      printf "[$i/20] Checking Postgres is up...\n"
-                      pg_isready -h 127.0.0.1
-                      if [ $? -eq 0 ]; then
-                        printf "Booted $IMAGE!\n"
-                        break
-                      elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
-                        printf "Failed to boot image\n"
-                        exit 1
-                      fi
-                      printf "[$i/20] No response. Sleeping 10s...\n"
-                      sleep 10s
-                    done
-                    printf "Running Test Command...\n"
-                    printf "Running Version Check...\n"
-                    VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
-                    if PGPASSWORD=passw0rd psql -h 127.0.0.1 -U user postgres -c "SELECT VERSION();" | grep $VERSION ; then
-                      printf "Version matches!\n"
-                    else
-                      printf "Version mismatch!\n"
-                      exit 1
-                    fi
-                    printf "Stopping $IMAGE...\n"
-                    docker stop $CONTAINER_ID >/dev/null 2>&1
-                  done
-                  printf "All images passed!\n"
+          # post-steps:
+          #   - run:
+          #       name: Install Prerequisites
+          #       command: |
+          #         sudo apt-get update && \
+          #         sudo apt-get install -y postgresql-client
+          #   - run:
+          #       name: Test Docker Images
+          #       shell: /bin/bash -o pipefail
+          #       command: |
+          #         ssh -f -N -L localhost:5432:localhost:5432 remote-docker
+          #         IMAGES=$(docker images --format='{{.Repository}}:{{.Tag}}' | grep "ccitest/postgres")
+          #         for IMAGE in $IMAGES; do
+          #           printf "Booting $IMAGE...\n"
+          #           CONTAINER_ID=$(docker run --rm --env POSTGRES_USER=user --env POSTGRES_PASSWORD=passw0rd -p 5432:5432 -d $IMAGE postgres -c 'config_file=/var/lib/postgresql/data/postgresql.conf')
+          #           for i in {1..20}; do
+          #             printf "[$i/20] Checking Postgres is up...\n"
+          #             pg_isready -h 127.0.0.1
+          #             if [ $? -eq 0 ]; then
+          #               printf "Booted $IMAGE!\n"
+          #               break
+          #             elif [ $? -ne 0 ] && [ $i -eq 20 ]; then
+          #               printf "Failed to boot image\n"
+          #               exit 1
+          #             fi
+          #             printf "[$i/20] No response. Sleeping 10s...\n"
+          #             sleep 10s
+          #           done
+          #           printf "Running Test Command...\n"
+          #           printf "Running Version Check...\n"
+          #           VERSION=$(echo $IMAGE | cut -d ":" -f2 | cut -d "-" -f1)
+          #           if PGPASSWORD=passw0rd psql -h 127.0.0.1 -U user postgres -c "SELECT VERSION();" | grep $VERSION ; then
+          #             printf "Version matches!\n"
+          #           else
+          #             printf "Version mismatch!\n"
+          #             exit 1
+          #           fi
+          #           printf "Stopping $IMAGE...\n"
+          #           docker stop $CONTAINER_ID >/dev/null 2>&1
+          #         done
+          #         printf "All images passed!\n"
             - slack/notify:
                 branch_pattern: release-v.+
                 event: pass

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2023.04
+FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -77,7 +77,7 @@ RUN BUILD_DEPS="clang \
 		--with-lz4 \
 	&& \
 	# we can change from world to world-bin in newer releases
-	make world && \
+	make -j $(nproc) world && \
 	make install-world && \
 	cd .. && rm -rf postgresql-${PG_VER} \
 	&& \
@@ -92,7 +92,7 @@ RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${PARTMAN_VERSIO
 
 # Install pgTAP & pg_prove utility.
 RUN git clone --depth 1 -b "v$PGTAP_VERSION" https://github.com/theory/pgtap.git /pgtap && \
-	cd /pgtap && make && make install && \
+	cd /pgtap && make -j $(nproc) && make install && \
 	curl -sL https://cpanmin.us | perl - App::cpanminus && \
 	cpanm -n TAP::Parser::SourceHandler::pgTAP && \
 	rm -rf /pgtap

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=postgres
 parent=base
 variants=(postgis)
 namespace=cimg
+arm64=1

--- a/variants/postgis.Dockerfile.template
+++ b/variants/postgis.Dockerfile.template
@@ -6,6 +6,10 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 ENV POSTGIS_VER=3.2.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
+		clang \
+		libclang-dev \
+		llvm \
+		llvm-dev \
 		libgdal-dev \
 		libgeos-dev \
 		libjson-c-dev \
@@ -19,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	curl -sSL "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VER}.tar.gz" | tar -xz && \
 	cd postgis-${POSTGIS_VER} && \
 	./configure && \
-	make && \
+	make -j $(nproc) && \
 	make install && \
 	echo "CREATE EXTENSION postgis;" > /docker-entrypoint-initdb.d/postgis.sql
 


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb

This also fixes build failures in the postgis variant and optimises building to utilise all the cpu available for faster builds

For now the testing portion is removed due to how buildx jobs work, but we will revisit this at a later date. I have manually verified these images run Postgres successfully

Test build for all in-support versions: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-postgres/421/workflows/f1e82e94-8556-4d9f-8946-a2d30f822c2c/jobs/404

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
