### PR TITLE
feat: automate postgis versioning

### DIFF
--- a/postgresFeed.sh
+++ b/postgresFeed.sh
@@ -8,8 +8,24 @@ else
   exit 1
 fi
 
+getPostGISVersion() {
+  local templateFile=$1
+  RSS_URL="https://github.com/postgis/postgis/tags.atom"
+  VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
+
+  for version in $VERSIONS; do
+    if [[ $version =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+      generateVersions "$version"
+      generateSearchTerms "POSTGIS_VER=" "$templateFile" ""
+      replaceVersions "POSTGIS_VER=" "$SEARCH_TERM" true
+    fi
+  done
+}
 
 getPostgresVersion() {
+  echo "Getting latest PostGIS version..."
+  getPostGISVersion "variants/postgis.Dockerfile.template"
+
   RSS_URL="https://github.com/postgres/postgres/tags.atom"
   VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
 
@@ -17,7 +33,7 @@ getPostgresVersion() {
     if [[ $version =~ ^REL_[0-9]+(\_[0-9]+)*$ ]]; then
       generateVersions "$(echo "$version" | sed -r 's/REL_//g; s/_/./g')"
       generateSearchTerms "PG_VER=" "$majorMinor/Dockerfile" ""
-      directoryCheck "$majorMinor" "$SEARCH_TERM"
+      directoryCheck "$majorMinor" "$SEARCH_TERM" true
     fi
   done
 }


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Pulls in an updated postgis version when a new postgres version has been detected

# Reasons
postgis was seldom being updated - the repository itself does not release that often. With postgres already having EOL'd versions 10 and 11, and with postgres 16 being released, the version of postGIS we were using is not compatible. This aims to ensure the postgis version is updated and supports the versions that postgres themselves do

# Checklist

Please check through the following before opening your PR. Thank you!

- [no] I have made changes to the `Dockerfile.template` file only
this changes the postgresFeed script
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
