### PR TITLE
refactor: remove releases.txt and set EOL version

### DIFF
--- a/postgresFeed.sh
+++ b/postgresFeed.sh
@@ -31,6 +31,7 @@ getPostGISVersion() {
 }
 
 getPostgresVersion() {
+  EOL_VERSION=11
   echo "Getting latest PostGIS version..."
   getPostGISVersion "variants/postgis.Dockerfile.template"
 
@@ -41,7 +42,7 @@ getPostgresVersion() {
   VERSIONS=$(curl --silent "$RSS_URL" | grep -E '(title)' | tail -n +2 | sed -e 's/^[ \t]*//' | sed -e 's/<title>//' -e 's/<\/title>//')
 
   for version in $VERSIONS; do
-    if [[ $version =~ ^REL_[0-9]+(\_[0-9]+)*$ ]]; then
+    if [[ $version =~ ^REL_[0-9]+(\_[0-9]+)*$ && $(echo "$version" | awk -F '_' '{print $2}') -gt "$EOL_VERSION" ]]; then
       generateVersions "$(echo "$version" | sed -r 's/REL_//g; s/_/./g')"
       generateSearchTerms "PG_VER=" "$majorMinor/Dockerfile" ""
       directoryCheck "$majorMinor" "$SEARCH_TERM" true
@@ -53,6 +54,7 @@ getPostgresVersion() {
 getPostgresVersion
 
 if [ -n "${vers[*]}" ]; then
+  rm -rf releases.txt
   echo "Included version updates: ${vers[*]}"
   echo "Running release script"
   ./shared/release.sh "${vers[@]}"


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Set a condition to not update EOL versions and remove the releases.txt file that is generated for checking source downloads

# Reasons
This was adding a file to the generated releases that we do not want to keep, and we do not support EOL versions. A separate PR should be made to remove the major versions in the repository to clean it up

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
