### PR TITLE
Add pgvector support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,7 @@ ENV PGDATA /var/lib/postgresql/data
 ENV POSTGRES_DB=circle_test
 ENV PGTAP_VERSION 1.2.0
 ENV PARTMAN_VERSION 4.7.2
+ENV PGVECTOR_VERSION 0.5.1
 
 USER root
 RUN BUILD_DEPS="clang \
@@ -84,6 +85,12 @@ RUN BUILD_DEPS="clang \
 	git clone --depth 1 https://github.com/citusdata/pg_cron.git /pg_cron && \
 	cd /pg_cron && make && PATH=$PATH make install && \
 	rm -rf /pg_cron && \
+  cd .. && \
+  git clone --depth 1 -b v${PGVECTOR_VERSION} https://github.com/pgvector/pgvector.git /pgvector && \
+  cd /pgvector && \
+  make && \
+  make install && \
+  rm -rf /pgvector && \
 	apt-get purge -y --auto-remove $BUILD_DEPS
 
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${PARTMAN_VERSION}.tar.gz" | tar -xz && \


### PR DESCRIPTION
# Description
Adds support for [pgvector](https://github.com/pgvector/pgvector), an extension essential to working with GPT4, and isn't included natively in contrib.

# Reasons
I haven't been able to find an effective way to add pgvector support to CircleCI without a custom image—this PR brings pgvector support of the box. pgvector is useful for training LLMs, e.g. GPT4, adding embeddings and similarity queries to Postgres.

> An embedding is a vector (list) of floating point numbers. The between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
> 
> https://platform.openai.com/docs/guides/embeddings/what-are-embeddings

NOTE: I added the installation steps for pgvector to the initial `RUN` as `apt-get purge` removes `clang`, which is necessary for `make install`.

# Checklist
- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
