### PR TITLE
Update pg_cron.sh to use  instead of hard coded path

### DIFF
--- a/pg_cron.sh
+++ b/pg_cron.sh
@@ -12,11 +12,11 @@ chgrp postgres $customconf
 cat /etc/postgresql/custom-postgresql.conf
 
 # include custom config from main config
-conf=/var/lib/postgresql/data/postgresql.conf
+conf="$PGDATA/postgresql.conf"
 found=$(grep "include = '$customconf'" $conf)
 if [ -z "$found" ]; then
   echo "include = '$customconf'" >> $conf
 fi
 
-cat /var/lib/postgresql/data/postgresql.conf | grep shared
-cat /var/lib/postgresql/data/postgresql.conf | grep include
+cat "$PGDATA/postgresql.conf" | grep shared
+cat "$PGDATA/postgresql.conf" | grep include


### PR DESCRIPTION
# Description
Updates `pg_cron.sh` to use the `PGDATA` environment variable instead of a hardcoded Postgres data directory path.

# Reasons
Fix for #113. 

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
