### PR TITLE
ci: Update to latest circleci/cimg orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.6.0
+  cimg: circleci/cimg@0.6.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
* Update to the latest release (v0.6.1) of the circleci/cimg orb

# Reasons
The previous multi-release of cimg-postgres images had a script failure after the images had been published that referenced the command `appendToManifest` not being found. v0.6.1 removes the reference to this no-longer-used command.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
