### PR TITLE
refactor: flag to control pg_cron setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ This is no longer the case.
 We're determining how much of a performance increase does this variant actually give before we decide to bring it back.
 If you used the legacy PostgreSQL image and you have data on the ram vs non-ram variant build times, please open a GitHub Issue and let us know.
 
+#### Feature Control
+
+To disable the PostgreSQL extension `pg_cron` set the Environment Variable `DISABLE_PG_CRON` to the value `true`
+
+```yaml
+jobs:
+  build:
+    docker:
+      - image: cimg/postgres:13.1-postgis
+        environment:
+          DISABLE_PG_CRON: true
+    steps:
+      - checkout
+      - run: echo "Do things"
+```
 
 ### Tagging Scheme
 

--- a/pg_cron.sh
+++ b/pg_cron.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+# set DISABLE_PG_CRON to false if unset
+DISABLE_PG_CRON=${DISABLE_PG_CRON:-false}
+
+# if DISABLE_PG_CRON is set to true then exit gracefully
+# as the runner has opted not to use pg_cron
+if [ "${DISABLE_PG_CRON}" = true ]; then
+  exit 0
+fi
+
 # use same db as the one from env
 dbname="$POSTGRES_DB"
 


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description

Add a EnvVar flag to disable pg_cron.

# Reasons

The back story here is that we completely tear-down the DB set by the EnvVar `POSTGRES_DB` but this is not possible when pg_cron is enabled.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
