### PR TITLE
fix: remove build-essential to prevent llvm package purge

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -21,10 +21,9 @@ ENV PARTMAN_VERSION=4.7.2
 
 USER root
 RUN BUILD_DEPS="bison \
-        build-essential \
-        clang \
+		clang \
 		dirmngr \
-        flex \
+		flex \
 		gnupg \
 		libclang-dev \
 		libicu-dev \
@@ -57,7 +56,7 @@ RUN BUILD_DEPS="bison \
 	./configure \
 		--prefix=/usr/lib/postgresql/$PG_MAJOR \
 		--enable-integer-datetimes \
-        --enable-thread-safety \
+		--enable-thread-safety \
 		--enable-tap-tests \
 		--with-uuid=e2fs \
 		--with-gnu-ld \


### PR DESCRIPTION
# Description
Removes unnecessary `build-essential` package from build dependencies.

# Reasons
PostgreSQL requires `libllvm14` package for JIT compilation. 
The newly added `build-essential` in build dependencies causes `libllvm14` to be incorrectly purged during the cleanup phase.
As `build-essential` does not seem to be used during the build phase, we can remove it.
  
Fixes #129
 
# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
